### PR TITLE
Document exception and use it in containsDataType

### DIFF
--- a/bundles/org.palladiosimulator.generator.fluent/src/org/palladiosimulator/generator/fluent/repository/factory/FluentRepositoryFactory.java
+++ b/bundles/org.palladiosimulator.generator.fluent/src/org/palladiosimulator/generator/fluent/repository/factory/FluentRepositoryFactory.java
@@ -6,6 +6,7 @@ import java.util.logging.Logger;
 import org.eclipse.emf.ecore.plugin.EcorePlugin;
 import org.palladiosimulator.generator.fluent.exceptions.FluentApiException;
 import org.palladiosimulator.generator.fluent.exceptions.IllegalArgumentException;
+import org.palladiosimulator.generator.fluent.exceptions.NoSuchElementException;
 import org.palladiosimulator.generator.fluent.repository.api.Repo;
 import org.palladiosimulator.generator.fluent.repository.api.seff.InternalSeff;
 import org.palladiosimulator.generator.fluent.repository.api.seff.RecoverySeff;
@@ -997,7 +998,11 @@ public class FluentRepositoryFactory {
      * @see org.palladiosimulator.pcm.repository.DataType
      */
     public boolean containsDataType(final String name) {
-        return (this.repo.getDataType(name) != null) || (this.repo.getPrimitiveDataType(name) != null);
+        try {
+            return this.repo.getDataType(name) != null;
+        } catch (NoSuchElementException e) {
+            return false;
+        }
     }
 
     /**

--- a/bundles/org.palladiosimulator.generator.fluent/src/org/palladiosimulator/generator/fluent/repository/structure/RepositoryCreator.java
+++ b/bundles/org.palladiosimulator.generator.fluent/src/org/palladiosimulator/generator/fluent/repository/structure/RepositoryCreator.java
@@ -488,7 +488,7 @@ public class RepositoryCreator extends RepositoryEntity implements Repo, RepoAdd
                 final Primitive valueOf = Primitive.valueOf(adjustedName);
                 return this.internalPrimitives.get(valueOf);
             } catch (final IllegalArgumentException e) {
-                throw new NoSuchElementException(String.format("A primitive data type name '%s' was nou found.", name),
+                throw new NoSuchElementException(String.format("A primitive data type named '%s' was not found.", name),
                         e);
             }
         }
@@ -536,7 +536,7 @@ public class RepositoryCreator extends RepositoryEntity implements Repo, RepoAdd
         return collect.get(0);
     }
 
-    public DataType getDataType(final String name) {
+    public DataType getDataType(final String name) throws NoSuchElementException {
         IllegalArgumentException.throwIfNull(name, "name must not be null");
         final String[] split = name.split("\\.");
         if (split.length == 2) {
@@ -554,7 +554,8 @@ public class RepositoryCreator extends RepositoryEntity implements Repo, RepoAdd
                 "To access entities from imported repositories use the format <importedRepositoryName>.<entityName>");
     }
 
-    private DataType getDataTypeFromList(final String name, final List<DataType> dataTypes) {
+    private DataType getDataTypeFromList(final String name, final List<DataType> dataTypes)
+            throws NoSuchElementException {
         final List<DataType> collect = new ArrayList<>();
         final List<CollectionDataType> collectColl = dataTypes.stream()
             .filter(d -> d instanceof CollectionDataType)


### PR DESCRIPTION
getPrimitiveDataType is included in getDataType, therefore
it can be omitted.